### PR TITLE
Update fetchData.sh

### DIFF
--- a/scripts/fetchData.sh
+++ b/scripts/fetchData.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 set -e
-maxpage=6
+maxpage=13
 
-for i in {1..$maxpage}
+for ((i=0; i<maxpage; i++))
 do
-	curl "https://www.kaggle.com/competitions.json?sortBy=deadline&group=all&segment=featured&page=${i}" -o "file-${i}.json"
+	curl "https://www.kaggle.com/competitions.json?sortBy=deadline&group=all&segment=allCategories&page=${i}" -o "file-${i}.json"
 done
 
 jq '.competitions[]' file-* | jq -s . > competitions.json
 
-for i in {1..$maxpage}
+for ((i=0; i<maxpage; i++))
 do
 	rm "./file-${i}.json"
 done


### PR DESCRIPTION
`segment` was set to `featured`, thereby missing many valid competitions (unless that was intentional?) Valid labels so far are: `allCategories, featured, recruitment, research, playground, gettingStarted, inClass`. Also increased `maxpage` to 13.

Replaced the `for` loops with valid bash loops as bash doesn't support the `{1..$maxpage}` syntax ([shellcheck SC2051](https://github.com/koalaman/shellcheck/wiki/SC2051)) Also the loops now start at `0` instead of `1`.

No idea though how to best merge the current competitions.json with the new one.